### PR TITLE
Bump to latest amplify version

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "test": "node node_modules/jest/bin/jest.js --watch"
   },
   "dependencies": {
-    "aws-amplify-react-native": "^0.1.21",
+    "aws-amplify-react-native": "^0.1.22",
     "aws-sdk": "2.177.0",
     "buffer": "^5.0.7",
     "mime-type": "^3.0.5",


### PR DESCRIPTION
Forcing to use latest aws-amplify-react-native