### PR TITLE
Update SignIn.js

### DIFF
--- a/client/lib/Categories/Auth/Components/Examples/SignIn.js
+++ b/client/lib/Categories/Auth/Components/Examples/SignIn.js
@@ -35,7 +35,7 @@ class SignIn extends React.Component {
       errorMessage: null,
     };
 
-    this.resolver = Promise.resolve();
+    this.resolver = () => null;
 
     this.handleSignIn = this.handleSignIn.bind(this);
     this.doSignIn = this.doSignIn.bind(this);

--- a/client/lib/Categories/Auth/Components/Examples/SignUp.js
+++ b/client/lib/Categories/Auth/Components/Examples/SignUp.js
@@ -34,7 +34,7 @@ class SignUp extends React.Component {
       errorMessage: null,
     };
 
-    this.resolver = Promise.resolve();
+    this.resolver = () => null;
 
     this.handleSignUp = this.handleSignUp.bind(this);
     this.doSignUp = this.doSignUp.bind(this);


### PR DESCRIPTION
Fixes #67 

`this.resolver` is never called as a resolved promise, it is used in `doSignIn`, `handleMFACancel` and `handleMFASuccess`:

- `doSignIn` sets it to a resolve function on each invocation
- `handleMFACancel` and `handleMFASuccess` are only called when MFA is required and *after* `doSignIn`

This commit sets `this.resolver` to a "no-op" 